### PR TITLE
Sharing grid config to other users

### DIFF
--- a/src/Controller/Admin/DataObject/DataObjectHelperController.php
+++ b/src/Controller/Admin/DataObject/DataObjectHelperController.php
@@ -1042,7 +1042,7 @@ class DataObjectHelperController extends AdminAbstractController
             $favourite->setGridConfigId($gridConfig->getId());
             $favourite->setClassId($gridConfig->getClassId());
             $favourite->setObjectId($objectId);
-            $favourite->setOwnerId($id);
+            $favourite->setOwnerId((int) $id);
             $favourite->setType($gridConfig->getType());
             $favourite->setSearchType($gridConfig->getSearchType());
             $favourite->save();


### PR DESCRIPTION
Bugfix for sharing grid configs to other users.

Can be replicated on `demo.pimcore.fun`. Steps to recreate:
1. First create a grid config, and navigate to 'Save & Share'.
2. Add users. Do not set 'Share globally'.
3. Save & Share